### PR TITLE
Add optional predicted tracks layer to visualize_gt

### DIFF
--- a/example_2d.py
+++ b/example_2d.py
@@ -67,6 +67,7 @@ v = divis.visualize_gt(
     masks=pred.segmentation,
     # networkx graph at traccuracy.TrackingGraph.graph
     graph=gt_graph.graph,
+    pred_graph=pred_graph.graph,
 )
 
 v = divis.visualize_edge_errors(

--- a/example_3d.py
+++ b/example_3d.py
@@ -117,6 +117,7 @@ v = divis.visualize_gt(
     masks=pred.segmentation,
     # networkx graph at traccuracy.TrackingGraph.graph
     graph=gt_graph.graph,
+    pred_graph=pred_graph.graph,
 )
 
 v = divis.visualize_edge_errors(

--- a/src/divisualisation/divisualisation.py
+++ b/src/divisualisation/divisualisation.py
@@ -31,6 +31,7 @@ class Divisualisation:
         x: np.ndarray,
         masks: np.ndarray,
         graph: nx.DiGraph,
+        pred_graph: nx.DiGraph | None = None,
         time_attr: str = "t",
     ):
         # Pseudo 3rd dimension for 2d datasets
@@ -94,6 +95,39 @@ class Divisualisation:
             opacity=1.0,
         )
 
+        # Optionally add predicted tracks layer
+        pred_tracks_layer = None
+        if pred_graph is not None:
+            pred_tracks, _, pred_properties = graph_to_napari_tracks(
+                pred_graph,
+                properties=[time_attr],
+            )
+            pred_properties["pred"] = (
+                np.ones_like(pred_properties[time_attr]) * 0.5
+            )
+            pred_properties = {"pred": pred_properties["pred"]}
+            logger.info("Adding pred tracks")
+
+            assert pred_tracks.shape[1] == 5
+            pred_tracks[:, -3] = (
+                pred_tracks[:, -3] + self.time_scale * pred_tracks[:, -4]
+            )
+
+            pred_tracks_layer = v.add_tracks(
+                data=pred_tracks,
+                name="pred_tracks",
+                properties=pred_properties,
+                color_by="pred",
+                blending="translucent_no_depth",
+                colormaps_dict={
+                    "pred": vispy_or_mpl_colormap("Reds"),
+                },
+                tail_width=self.tracks_width,
+                tail_length=1000,
+                opacity=1.0,
+                visible=False,
+            )
+
         def update_gt_state(event=None):
             t = v.dims.point[0]
             clipping_planes_tracks = [
@@ -110,6 +144,11 @@ class Divisualisation:
             ]
             tracks_layer.experimental_clipping_planes = clipping_planes_tracks
             tracks_layer.translate = [0, -self.time_scale * t, 0, 0]
+            if pred_tracks_layer is not None:
+                pred_tracks_layer.experimental_clipping_planes = (
+                    clipping_planes_tracks
+                )
+                pred_tracks_layer.translate = [0, -self.time_scale * t, 0, 0]
 
         v.dims.events.point.connect(update_gt_state)
         v.dims.ndisplay = 3


### PR DESCRIPTION
## Summary
- Adds an optional `pred_graph` parameter to `visualize_gt()` that, when provided, plots the predicted graph as a tracks layer named `pred_tracks`
- The layer uses the `Reds` colormap and is hidden by default (`visible=False`)
- Clipping planes and time-based translation are shared with the GT tracks layer
- Both example scripts updated to pass `pred_graph`

## Test plan
- [ ] Run `example_2d.py` and verify `pred_tracks` layer appears in napari layer list, hidden by default
- [ ] Toggle `pred_tracks` visibility and confirm red tracks render correctly
- [ ] Scrub through time and verify clipping/translation updates for both GT and pred tracks
- [ ] Run `example_3d.py` and repeat the above checks
- [ ] Call `visualize_gt` without `pred_graph` and confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)